### PR TITLE
Bump resolver and libraries

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -19,7 +19,7 @@ license: MIT
 license-file: LICENSE
 author: Adam McCullough <merlinfmct87@gmail.com>
 maintainer: Adam McCullough <merlinfmct87@gmail.com>
-copyright: © 2021
+copyright: © 2021-2022 Adam McCullough and Others
 tested-with: GHC == 8.10.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,9 @@
-resolver: lts-18.12
+resolver: lts-18.25
 
 packages:
   - .
 
 extra-deps:
-  - github: aesiniath/unbeliever
-    commit: HEAD
-    subdirs:
-      - core-data
-      - core-program
-      - core-text
+  - core-text-0.3.5.0
+  - core-data-0.3.1.1
+  - core-program-0.4.4.0


### PR DESCRIPTION
Bump resolver to latest in `lts-18` series and bump dependencies on the unbeliever packages to the latest released as well (no longer needs to depend on unreleased **core-program**)